### PR TITLE
Bump rubyzip gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,7 +297,7 @@ GEM
     rspec-support (3.5.0)
     ruby_dep (1.4.0)
     ruby_http_client (3.0.0)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.5)
@@ -437,4 +437,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.1
+   1.16.0


### PR DESCRIPTION
Due to a reported vulnerability.

more: https://nvd.nist.gov/vuln/detail/CVE-2017-5946